### PR TITLE
Handle situation where JWT session tokens are already expired

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -351,19 +351,29 @@ async def logout(request: Request, response: Response):
 
     if auth_header:
         _, token = auth_header.split()
-        user_data = jwt.decode(
-            token,
-            get_jwt_secret(),
-            algorithms=["HS256"],
-            options={"verify_signature": True},
-        )
-        email = user_data.get("identifier")
-        if email and jwt_session_tokens.get(email):
-            # invalidate user session by removing it from cache
-            del jwt_session_tokens[email]
+        try:
+            # Verify the token and decode
+            user_data = jwt.decode(
+                token,
+                get_jwt_secret(),
+                algorithms=["HS256"],
+                options={"verify_exp": True}  # Verify expiration
+            )
+            email = user_data.get("identifier")
+            if email and jwt_session_tokens.get(email):
+                # Invalidate user session by removing it from cache
+                del jwt_session_tokens[email]
+
+        except jwt.ExpiredSignatureError:
+            # Token has expired; log the user out but don't try to delete the session
+            return {"success": True, "message": "Token expired, logged out successfully."}
+        except jwt.InvalidTokenError:
+            # Handle invalid token error
+            return {"success": False, "message": "Invalid token."}
 
     if config.code.on_logout:
         return await config.code.on_logout(request, response)
+
     return {"success": True}
 
 

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -352,7 +352,7 @@ async def logout(request: Request, response: Response):
     if auth_header:
         _, token = auth_header.split()
         try:
-            # Verify the token and decode
+            # Decode the token with signature and expiration verification
             user_data = jwt.decode(
                 token,
                 get_jwt_secret(),
@@ -368,8 +368,11 @@ async def logout(request: Request, response: Response):
             # Token has expired; log the user out but don't try to delete the session
             return {"success": True, "message": "Token expired, logged out successfully."}
         except jwt.InvalidTokenError:
-            # Handle invalid token error
+            # Handle invalid token error including invalid signature
             return {"success": False, "message": "Invalid token."}
+        except jwt.InvalidSignatureError:
+            # Specific handling for invalid signature
+            return {"success": False, "message": "Invalid signature."}
 
     if config.code.on_logout:
         return await config.code.on_logout(request, response)


### PR DESCRIPTION
This PR fixes #2.

The code now verifies the token for expiry, and if the token is expired, there is no need to remove the record from cache, simply log the user out.

There is no need to manually remove expired tokens from cache because the cache `jwt_session_tokens` is already configured within `chainlit/auth_ext.py` to expire based on `user_session_timeout` -- which we can set inside `.chainlit/config.toml`. `TTLCache` manages the removal of the record once the TTL expires, so the cache will no longer hold references to expired token.

`del jwt_session_tokens[email]` remains only executed when the token signature is valid so that there is no unauthorised tampering with cache.