### PR TITLE
fix: pin `poetry-core` to `1.9.1`

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -120,7 +120,7 @@ azure-storage-file-datalake = "^12.14.0"
 
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core==1.9.1"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
There is a bug in the recent `poetry-core` therefore we need to pin it to a working version.

Reference: https://github.com/Chainlit/chainlit/issues/1673